### PR TITLE
Do not track C methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dead_code_detector (0.0.7.alpha)
+    dead_code_detector (0.0.9)
 
 GEM
   remote: https://rubygems.org/
@@ -29,9 +29,9 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.17)
   byebug
+  dead_code_detector!
   rake (~> 10.0)
   rspec (~> 3.0)
-  dead_code_detector!
 
 BUNDLED WITH
    1.17.3

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ DeadCodeDetector.configure do |config|
 
   # DeadCodeDetector will filter out methods whose source_location matches this regular expression.
   # This is useful for filtering out methods from gems (such as the methods from ActiveRecord::Base)
+  # Specifying a value here will cause DeadCodeDetector to ignore methods defined in C
   # config.ignore_paths = /\/vendor\//
 
   # A list of classes that DeadCodeDetector will monitor method usage on.

--- a/lib/dead_code_detector/class_method_wrapper.rb
+++ b/lib/dead_code_detector/class_method_wrapper.rb
@@ -52,6 +52,7 @@ module DeadCodeDetector
     def target_directory?(method_name)
       return true if DeadCodeDetector.config.ignore_paths.nil?
       source_location = klass.method(method_name).source_location&.first
+      return false if source_location.nil?
       source_location !~ DeadCodeDetector.config.ignore_paths
     end
 

--- a/lib/dead_code_detector/instance_method_wrapper.rb
+++ b/lib/dead_code_detector/instance_method_wrapper.rb
@@ -46,6 +46,7 @@ module DeadCodeDetector
     def target_directory?(method_name)
       return true if DeadCodeDetector.config.ignore_paths.nil?
       source_location = klass.instance_method(method_name).source_location&.first
+      return false if source_location.nil?
       source_location !~ DeadCodeDetector.config.ignore_paths
     end
 

--- a/lib/dead_code_detector/version.rb
+++ b/lib/dead_code_detector/version.rb
@@ -1,3 +1,3 @@
 module DeadCodeDetector
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/spec/dead_code_detector/class_method_wrapper_spec.rb
+++ b/spec/dead_code_detector/class_method_wrapper_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe DeadCodeDetector::ClassMethodWrapper do
           end
         end
 
+        context "and the method doesn't have a source location" do
+          it "excludes it" do
+            allow_any_instance_of(Method).to receive(:source_location).and_return(nil)
+
+            expect do
+              described_class.new(anonymous_class).refresh_cache
+            end.to_not change{ DeadCodeDetector.config.storage.get(described_class.record_key(anonymous_class.name)) }
+
+          end
+        end
         it "includes the methods" do
           expect do
             described_class.new(anonymous_class).refresh_cache

--- a/spec/dead_code_detector/instance_method_wrapper_spec.rb
+++ b/spec/dead_code_detector/instance_method_wrapper_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe DeadCodeDetector::InstanceMethodWrapper do
           end
         end
 
+        context "and the method doesn't have a source location" do
+          it "excludes it" do
+            allow_any_instance_of(UnboundMethod).to receive(:source_location).and_return(nil)
+
+            expect do
+              described_class.new(anonymous_class).refresh_cache
+            end.to_not change{ DeadCodeDetector.config.storage.get(described_class.record_key(anonymous_class.name)) }
+          end
+        end
+
         it "includes the methods" do
           expect do
             described_class.new(anonymous_class).refresh_cache


### PR DESCRIPTION
When `ignore_paths` is configured, it means that the user of the Gem is wanting to avoid tracking methods that belong to certain file paths. 

For C methods, they have no file paths. This means that if we are tracking methods some within a codebase, DeadCodeDetector will track methods from Standard ruby libraries, or with C extensions. 

We will assume, for the moment, that most projects do not rely on C extensions and we will exclude these. If this becomes something we do want to track, we can add more configuration to include them. 

For now, we will just exclude them. 