### PR TITLE
Don't track classes that have no methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dead_code_detector (0.0.9)
+    dead_code_detector (0.0.10)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/dead_code_detector/base_method_wrapper.rb
+++ b/lib/dead_code_detector/base_method_wrapper.rb
@@ -23,6 +23,10 @@ module DeadCodeDetector
       end
     end
 
+    def number_of_tracked_methods
+      default_methods.count
+    end
+
     def clear_cache
       DeadCodeDetector.config.storage.clear(self.class.record_key(klass.name))
     end

--- a/lib/dead_code_detector/class_method_wrapper.rb
+++ b/lib/dead_code_detector/class_method_wrapper.rb
@@ -44,7 +44,7 @@ module DeadCodeDetector
     end
 
     def default_methods
-      klass.methods.map(&:to_s).select do |method_name|
+      @default_methods ||= klass.methods.map(&:to_s).select do |method_name|
         owned_method?(method_name) && target_directory?(method_name)
       end
     end

--- a/lib/dead_code_detector/initializer.rb
+++ b/lib/dead_code_detector/initializer.rb
@@ -61,9 +61,11 @@ module DeadCodeDetector
       end
 
       def cache_methods_for(klass)
-        DeadCodeDetector.config.storage.add(tracked_classes_key, klass.name)
-        DeadCodeDetector::ClassMethodWrapper.new(klass).refresh_cache
-        DeadCodeDetector::InstanceMethodWrapper.new(klass).refresh_cache
+        class_wrapper = DeadCodeDetector::ClassMethodWrapper.new(klass).tap(&:refresh_cache)
+        instance_wrapper = DeadCodeDetector::InstanceMethodWrapper.new(klass).tap(&:refresh_cache)
+        if class_wrapper.number_of_tracked_methods + instance_wrapper.number_of_tracked_methods > 0
+          DeadCodeDetector.config.storage.add(tracked_classes_key, klass.name)
+        end
       end
 
       def tracked_classes_key

--- a/lib/dead_code_detector/instance_method_wrapper.rb
+++ b/lib/dead_code_detector/instance_method_wrapper.rb
@@ -38,7 +38,7 @@ module DeadCodeDetector
     end
 
     def default_methods
-      klass.instance_methods.map(&:to_s).select do |method_name|
+      @default_methods ||= klass.instance_methods.map(&:to_s).select do |method_name|
         owned_method?(method_name) && target_directory?(method_name)
       end
     end

--- a/lib/dead_code_detector/version.rb
+++ b/lib/dead_code_detector/version.rb
@@ -1,3 +1,3 @@
 module DeadCodeDetector
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/spec/dead_code_detector/initializer_spec.rb
+++ b/spec/dead_code_detector/initializer_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe DeadCodeDetector::Initializer do
         .to(true)
     end
 
+    context "when the class has no tracked methods" do
+      let(:anonymous_class) { Class.new }
+      it "doesn't include it in the cached classes" do
+        expect do
+          described_class.refresh_cache_for(anonymous_class)
+        end.to_not change{ DeadCodeDetector::Initializer.cached_classes }
+      end
+    end
   end
 
   describe ".enable" do


### PR DESCRIPTION
If we are not tracking any methods for a class, we shouldn't add it into the classes we are tracking. 

This is important if someone is planning on tracking any descendants from `Object` (i.e. everything) 