### PR TITLE
Bei buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,7 @@
+steps:
+  - label: ":rspec: RSpec"
+    command:
+      - "echo '--- :ruby: bundle install'"
+      - bundle install
+      - "echo '--- :rspec: rspec'"
+      - bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,4 +34,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.3
+   1.16.6


### PR DESCRIPTION
### Whatcha doin?
Getting CI setup to run repos specs

### Why?
We should be running specs for our repos and it allows us to display a build pass/fail badge for other open source users.
