### PR TITLE
Minimize cost when enabling on all objects

### DIFF
--- a/lib/dead_code_detector/base_method_wrapper.rb
+++ b/lib/dead_code_detector/base_method_wrapper.rb
@@ -33,7 +33,9 @@ module DeadCodeDetector
 
     def refresh_cache
       clear_cache
-      DeadCodeDetector.config.storage.add(self.class.record_key(klass.name), default_methods)
+      if default_methods.any?
+        DeadCodeDetector.config.storage.add(self.class.record_key(klass.name), default_methods)
+      end
     end
 
     private

--- a/lib/dead_code_detector/class_method_wrapper.rb
+++ b/lib/dead_code_detector/class_method_wrapper.rb
@@ -59,7 +59,11 @@ module DeadCodeDetector
 
     def owned_method?(method_name)
       original_method = klass.method(method_name)
-      klass.singleton_class <= original_method.owner && !(klass.superclass.singleton_class <= original_method.owner)
+      if klass.respond_to?(:superclass)
+        klass.singleton_class <= original_method.owner && !(klass.superclass.singleton_class <= original_method.owner)
+      else
+        klass.singleton_class <= original_method.owner
+      end
     end
 
   end

--- a/lib/dead_code_detector/class_method_wrapper.rb
+++ b/lib/dead_code_detector/class_method_wrapper.rb
@@ -53,6 +53,7 @@ module DeadCodeDetector
       return true if DeadCodeDetector.config.ignore_paths.nil?
       source_location = klass.method(method_name).source_location&.first
       return false if source_location.nil?
+      return false if source_location == "(eval)"
       source_location !~ DeadCodeDetector.config.ignore_paths
     end
 

--- a/lib/dead_code_detector/configuration.rb
+++ b/lib/dead_code_detector/configuration.rb
@@ -1,7 +1,7 @@
 module DeadCodeDetector
   class Configuration
 
-    attr_accessor :redis, :classes_to_monitor, :error_handler, :allowed, :cache_expiry, :ignore_paths
+    attr_accessor :redis, :classes_to_monitor, :error_handler, :allowed, :cache_expiry, :ignore_paths, :max_seconds_to_enable
 
     STORAGE_BACKENDS = {
       memory: Storage::MemoryBackend,
@@ -12,6 +12,7 @@ module DeadCodeDetector
       @allowed = true
       @classes_to_monitor = []
       @cache_expiry = 60 * 60 * 24 * 14
+      @max_seconds_to_enable = 1
     end
 
     def storage=(backend_type)

--- a/lib/dead_code_detector/initializer.rb
+++ b/lib/dead_code_detector/initializer.rb
@@ -3,6 +3,8 @@ module DeadCodeDetector
 
     class << self
 
+      attr_accessor :fully_enabled, :last_enabled_class
+
       def refresh_caches
         DeadCodeDetector.config.classes_to_monitor.each do |klass|
           refresh_cache_for(klass)
@@ -10,8 +12,8 @@ module DeadCodeDetector
       end
 
       def refresh_cache_for(klass)
-        @fully_enabled = false
-        @last_enabled_class = nil
+        self.fully_enabled = false
+        self.last_enabled_class = nil
         classes = [klass, *descendants_of(klass)]
         classes.each do |class_to_enable|
           cache_methods_for(class_to_enable)
@@ -35,18 +37,18 @@ module DeadCodeDetector
       end
 
       def enable_for_cached_classes!
-        return if @fully_enabled
+        return if fully_enabled
         return unless allowed?
         classes = cached_classes.sort.to_a
-        starting_index = classes.index(@last_enabled_class) || 0
+        starting_index = (classes.index(@last_enabled_class) || -1) + 1
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         classes[starting_index..-1].each do |class_name|
           klass = Object.const_get(class_name) rescue nil
           enable(klass) if klass
-          @last_enabled_class = class_name
+          self.last_enabled_class = class_name
           return if Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time > DeadCodeDetector.config.max_seconds_to_enable
         end
-        @fully_enabled = true
+        self.fully_enabled = true
       end
 
       def allowed?

--- a/lib/dead_code_detector/initializer.rb
+++ b/lib/dead_code_detector/initializer.rb
@@ -10,7 +10,8 @@ module DeadCodeDetector
       end
 
       def refresh_cache_for(klass)
-        @enabled = false
+        @fully_enabled = false
+        @last_enabled_class = nil
         classes = [klass, *descendants_of(klass)]
         classes.each do |class_to_enable|
           cache_methods_for(class_to_enable)
@@ -34,13 +35,18 @@ module DeadCodeDetector
       end
 
       def enable_for_cached_classes!
-        return if @enabled
+        return if @fully_enabled
         return unless allowed?
-        @enabled = true
-        cached_classes.each do |class_name|
+        classes = cached_classes.sort.to_a
+        starting_index = classes.index(@last_enabled_class) || 0
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        classes[starting_index..-1].each do |class_name|
           klass = Object.const_get(class_name) rescue nil
           enable(klass) if klass
+          @last_enabled_class = class_name
+          return if Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time > DeadCodeDetector.config.max_seconds_to_enable
         end
+        @fully_enabled = true
       end
 
       def allowed?

--- a/lib/dead_code_detector/initializer.rb
+++ b/lib/dead_code_detector/initializer.rb
@@ -40,7 +40,7 @@ module DeadCodeDetector
         return if fully_enabled
         return unless allowed?
         classes = cached_classes.sort.to_a
-        starting_index = (classes.index(@last_enabled_class) || -1) + 1
+        starting_index = (classes.index(last_enabled_class) || -1) + 1
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         classes[starting_index..-1].each do |class_name|
           klass = Object.const_get(class_name) rescue nil

--- a/lib/dead_code_detector/initializer.rb
+++ b/lib/dead_code_detector/initializer.rb
@@ -57,7 +57,9 @@ module DeadCodeDetector
 
       private
       def descendants_of(parent_class)
-        ObjectSpace.each_object(parent_class.singleton_class).select { |klass| klass < parent_class }
+        ObjectSpace.each_object(parent_class.singleton_class).select do |klass|
+          klass < parent_class && !klass.anonymous?
+        end
       end
 
       def cache_methods_for(klass)

--- a/lib/dead_code_detector/initializer.rb
+++ b/lib/dead_code_detector/initializer.rb
@@ -66,7 +66,7 @@ module DeadCodeDetector
       private
       def descendants_of(parent_class)
         ObjectSpace.each_object(parent_class.singleton_class).select do |klass|
-          klass < parent_class && !klass.anonymous?
+          klass < parent_class && !klass.name.nil?
         end
       end
 

--- a/lib/dead_code_detector/instance_method_wrapper.rb
+++ b/lib/dead_code_detector/instance_method_wrapper.rb
@@ -53,7 +53,11 @@ module DeadCodeDetector
 
     def owned_method?(method_name)
       original_method = klass.instance_method(method_name)
-      klass <= original_method.owner && !(klass.superclass <= original_method.owner)
+      if klass.respond_to?(:superclass)
+        klass <= original_method.owner && !(klass.superclass <= original_method.owner)
+      else
+        klass <= original_method.owner
+      end
     end
 
   end

--- a/lib/dead_code_detector/instance_method_wrapper.rb
+++ b/lib/dead_code_detector/instance_method_wrapper.rb
@@ -47,6 +47,7 @@ module DeadCodeDetector
       return true if DeadCodeDetector.config.ignore_paths.nil?
       source_location = klass.instance_method(method_name).source_location&.first
       return false if source_location.nil?
+      return false if source_location == "(eval)"
       source_location !~ DeadCodeDetector.config.ignore_paths
     end
 

--- a/spec/dead_code_detector/class_method_wrapper_spec.rb
+++ b/spec/dead_code_detector/class_method_wrapper_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe DeadCodeDetector::ClassMethodWrapper do
           end
         end
 
+        context "and the method has an eval source location" do
+          it "excludes it" do
+            allow_any_instance_of(Method).to receive(:source_location).and_return(["(eval)"])
+
+            expect do
+              described_class.new(anonymous_class).refresh_cache
+            end.to_not change{ DeadCodeDetector.config.storage.get(described_class.record_key(anonymous_class.name)) }
+          end
+        end
+
         context "and the method doesn't have a source location" do
           it "excludes it" do
             allow_any_instance_of(Method).to receive(:source_location).and_return(nil)
@@ -105,7 +115,6 @@ RSpec.describe DeadCodeDetector::ClassMethodWrapper do
         .from(Set.new)
         .to(Set.new(["bar", "name", "counter", "counter="]))
     end
-
 
     context "when the class contains methods from a module" do
       let(:anonymous_class) do

--- a/spec/dead_code_detector/instance_method_wrapper_spec.rb
+++ b/spec/dead_code_detector/instance_method_wrapper_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe DeadCodeDetector::InstanceMethodWrapper do
           end
         end
 
+        context "and the method has an eval source location" do
+          it "excludes it" do
+            allow_any_instance_of(UnboundMethod).to receive(:source_location).and_return(["(eval)"])
+
+            expect do
+              described_class.new(anonymous_class).refresh_cache
+            end.to_not change{ DeadCodeDetector.config.storage.get(described_class.record_key(anonymous_class.name)) }
+          end
+        end
+
         context "and the method doesn't have a source location" do
           it "excludes it" do
             allow_any_instance_of(UnboundMethod).to receive(:source_location).and_return(nil)


### PR DESCRIPTION
There is a few consequences to enabling the DeadCodeDetector on all descendants of `Object`

1) classes/modules provided by Gems will be included, so we need some better controls at filtering out methods. In particular methods whose source location is `"(eval)"` should be treated as if they don't have a source location
2) We don't need to store empty sets in the storage
3) `Module` gets included in the descendants of Object and they don't implement `superclass`
4) Because there are more methods being tracked, this can take a longer time so we will add a new configuration value so that we can set an upper bound on how long is acceptable to enable and only partially enable things. Subsequent calls to enable will pick up where it left off. 