### PR TITLE
Update wrap_method to support Ruby 3.0

### DIFF
--- a/lib/dead_code_detector/instance_method_wrapper.rb
+++ b/lib/dead_code_detector/instance_method_wrapper.rb
@@ -24,7 +24,7 @@ module DeadCodeDetector
 
     def wrap_method(original_method)
       original_class = klass
-      klass.send(:define_method, original_method.name) do |*args, &block|
+      klass.send(:define_method, original_method.name) do |*args, **kwargs, &block|
         begin
           DeadCodeDetector::InstanceMethodWrapper.unwrap_method(original_class, original_method)
         rescue StandardError => e
@@ -33,7 +33,7 @@ module DeadCodeDetector
           end
         end
         method_bound_to_caller = original_method.bind(self)
-        method_bound_to_caller.call(*args, &block)
+        method_bound_to_caller.call(*args, **kwargs, &block)
       end
     end
 


### PR DESCRIPTION
Partially Addresses: https://github.com/clio/dead_code_detector/issues/11

See also: https://github.com/clio/dead_code_detector/pull/13