### PR TITLE
Update class_method_wrapper_spec.rb to add a method with a keyword argument to demonstrate Ruby 3.0 compatibility

### DIFF
--- a/spec/dead_code_detector/class_method_wrapper_spec.rb
+++ b/spec/dead_code_detector/class_method_wrapper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DeadCodeDetector::ClassMethodWrapper do
         self.counter += 1
       end
       
-      def self.owenership_string(val, name: "Jo")
+      def self.ownership_string(val, name: "Jo")
         "#{name} has #{val} objects"
       end
     end

--- a/spec/dead_code_detector/class_method_wrapper_spec.rb
+++ b/spec/dead_code_detector/class_method_wrapper_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe DeadCodeDetector::ClassMethodWrapper do
         self.counter ||= 0
         self.counter += 1
       end
+      
+      def self.owenership_string(val, name: "Jo")
+        "#{name} has #{val} objects"
+      end
     end
   end
 


### PR DESCRIPTION
See also: https://github.com/clio/dead_code_detector/pull/13

>[!TIP]
> NOTE: All methods in this class are called dynamically in some of the specs, so simply including a method here with a keyword argument means that it will be tested.