### PR TITLE
Update class_method_wrapper.rb

### DIFF
--- a/lib/dead_code_detector/class_method_wrapper.rb
+++ b/lib/dead_code_detector/class_method_wrapper.rb
@@ -40,6 +40,7 @@ module DeadCodeDetector
         unbound_method = original_method.unbind
         method_bound_to_caller = unbound_method.bind(self)
         method_bound_to_caller.call(*args, **kwargs, &block)
+      end
     end
 
     def default_methods


### PR DESCRIPTION
### What is the problem?
When `wrap_method` was updated here:
https://github.com/clio/dead_code_detector/pull/13/files#diff-e0eed70e57656f78cc084465b65e7621535008e0760f8e421c739e60c37f4122L43

By mistake an extra `end` was removed.

This means when pulling the latest version and attempting to use it you end up with this error:
```
/usr/.../dead_code_detector-54907ad9a47f/lib/dead_code_detector/class_method_wrapper.rb:69:

syntax error, unexpected end-of-input, expecting `end' (SyntaxError)
```

### How does this solve it?
This adds back the missing end so we can use the gem!
