### PR TITLE
Update version.rb

### DIFF
--- a/lib/dead_code_detector/version.rb
+++ b/lib/dead_code_detector/version.rb
@@ -1,3 +1,3 @@
 module DeadCodeDetector
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end


### PR DESCRIPTION
### What is the problem?
After the keyword arguments were updated and the class method wrapper fixed in this PR:
https://github.com/clio/dead_code_detector/pull/15

We forgot to update the version.

### Why is this important?
Because there is no bumped version, installing the gem will default to the outdated code. Because of this we currently have to pin our gem installation against a specific revision. It would be nice to be able to bump the version so a new release is available for all users of this gem.

### How does this solve it?
This bumps the version to `0.0.11`.
