### PR TITLE
Remove the bundler requirement for the repo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler
   byebug
   dead_code_detector!
   rake (~> 13.0)

--- a/dead_code_detector.gemspec
+++ b/dead_code_detector.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
Address the 3 bundler CVEs flagged for this repo:

* https://github.com/clio/dead_code_detector/security/dependabot/3
* https://github.com/clio/dead_code_detector/security/dependabot/4
* https://github.com/clio/dead_code_detector/security/dependabot/6